### PR TITLE
autocomplete パネルを明示的に開く処理を実装.

### DIFF
--- a/src/app/component/use-angular-material/autocomplete/highlight-firs-item/highlight-firs-item.component.html
+++ b/src/app/component/use-angular-material/autocomplete/highlight-firs-item/highlight-firs-item.component.html
@@ -3,10 +3,15 @@
   <!-- appearance に設定できるのは 'legacy' | 'standard' | 'fill' | 'outline' のいずれか -->
   <mat-form-field class="form-full-width" appearance="fill">
     <mat-label>Number</mat-label>
+    <!-- autoCompleteInput はフォーカスをあてるために使用する､本要素を指定するためのテンプレート変数 -->
+    <!-- trigger は autocomplete パネルを開く処理: openPanel を実行するための MatAutocompleteTrigger オブジェクト -->
     <input type="text"
           placeholder="Pick one"
           aria-label="Number"
+          #autoCompleteInput
           matInput
+          #trigger="matAutocompleteTrigger"
+          (focus)="openPanel($event, trigger)"
           [formControl]="autocompleteControl"
           [matAutocomplete]="auto"
     >

--- a/src/app/component/use-angular-material/autocomplete/highlight-firs-item/highlight-firs-item.component.ts
+++ b/src/app/component/use-angular-material/autocomplete/highlight-firs-item/highlight-firs-item.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
+import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { Observable, of } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
@@ -13,6 +14,8 @@ export class HightlightFirstItemComponent implements OnInit {
   // NOTE: 下記のサンプル実装をもとに実装
   // https://material.angular.io/components/autocomplete/overview#automatically-highlighting-the-first-option
   //
+
+  @ViewChild('autoCompleteInput') autoCompleteInput!: ElementRef;
 
   // テンプレートの `input` からデータを流すための器
   // 入力された情報に応じてフィルタするために利用する
@@ -38,6 +41,25 @@ export class HightlightFirstItemComponent implements OnInit {
       // ここの処理で input で入力された内容に応じて表示するデータが絞り込まれる
       map((value) => this._filter(value || ''))
     );
+
+    // 画面表示時に入力欄にフォーカスをあてることで autocomplete パネルを表示させる
+    // ここ (ngOninit) でこれをやると､画面表示時に autocomplete パネルが開く
+    //
+    // 遅延評価させているのは描画時に発生するエラー対応
+    setTimeout(() => {
+      this.autoCompleteInput.nativeElement.focus();
+    }, 1);
+  }
+
+  // autocomplete のパネルを明示的に開くための処理
+  //
+  // 処理の流れは以下の通り
+  // 1. ngOnInit でテンプレート変数: autoCompleteInput に対して focus() でフォーカスをあてる
+  // 2. ページ描画時､テンプレートでは｢フォーカスがあたった｣となり､ focus イベントが発火する
+  // 3. focus イベントの発火を受けて､それに紐づく本メソッドが実行される
+  openPanel(event: Event, trigger: MatAutocompleteTrigger) {
+    event.stopPropagation();
+    trigger.openPanel();
   }
 
   private _filter(value: string): string[] {


### PR DESCRIPTION
本サンプル実装では画面描画時に入力欄にフォーカスをあて､ autocomplete パネルが開くようにしてみた.