### PR TITLE
ビルドエラーを解消.

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,12 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": []
+    "types": [
+      // NOTE: 下記エラーに対応
+      //   TS2591: Cannot find name 'Buffer'. Do you need to install type definitions for node?
+      //   Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
+      "node"
+    ]
   },
   "files": [
     "src/main.ts",


### PR DESCRIPTION
下記エラーが出てビルドに失敗していたので対応した｡

```bash
TS2591: Cannot find name 'Buffer'. Do you need to install type definitions for node?
Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
```
