### PR TITLE
vscode の設定で「検索対象」と「エクスプローラーの表示」から `node_modules` を除外した.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,4 +68,13 @@
   "markdownlint.config": {
     "MD033": false  // no-inline-html: Inline HTML [Element: details]markdownlintMD033 を黙らせる
   },
+
+  "search.exclude": {
+    // 検索対象から node_modules を外す
+    "**/node_modules": true
+  },
+  "files.exclude": {
+    // ファイルエクスプローラーから node_modules を外す
+    "**/node_modules": true
+  }
 }


### PR DESCRIPTION
これにより検索時に `node_modules` が対象になることはないし、`エクスプローラーに `node_modulse` が表示されることもない.